### PR TITLE
Update Werkzeug because of vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ six==1.12.0
 SQLAlchemy==1.3.0
 stop-words==2015.2.23.1
 urllib3==1.24.3
-Werkzeug==0.14.1
+Werkzeug==0.15.3


### PR DESCRIPTION
The version of Werkzeug we were using had a security Vulnerability. This
commit upgrades it.

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14806